### PR TITLE
Test modificar usuarios completado con éxito

### DIFF
--- a/sgart.backend/src/main/java/com/team1/sgart/backend/services/UserService.java
+++ b/sgart.backend/src/main/java/com/team1/sgart/backend/services/UserService.java
@@ -41,6 +41,17 @@ public class UserService {
 
 		return emailValido;
 	}
+	
+	public void modificarUser(User user) {
+		String email = user.getEmail();
+		if(!emailYaRegistrado(user)) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "El email no está registrado");
+		}else if (!emailFormatoValido(user)) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Formato del email incorrecto");
+		} else {
+			userDao.updateUser(email, user);
+		}
+	}
 
 	public boolean emailYaRegistrado(User user) {
 		boolean yaRegistrado = true;
@@ -59,16 +70,4 @@ public class UserService {
 
 		return passwordValido;
 	}
-
-	public void modificarUser(User user) {
-		String email = user.getEmail();
-		if (!emailFormatoValido(user)) {
-			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Formato del email incorrecto");
-		} else if (user.getPassword() != null && !passwordFormatoValido(user)) {
-			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Formato de la contraseña incorrecto");
-		} else {
-			userDao.updateUser(email, user);
-		}
-	}
-
 }

--- a/sgart.backend/src/test/java/com/team1/sgart/backend/http/UserControllerTest.java
+++ b/sgart.backend/src/test/java/com/team1/sgart/backend/http/UserControllerTest.java
@@ -26,9 +26,9 @@ class UserControllerTest {
 
     @MockBean
     private UserService userService;
-    
 
     private User user;
+
     @BeforeEach
     public void setUp() {
         user = new User("Carlos", "Romero Navarro", "Quality", "Ciudad Real", "carlos.romero@example.com", "01/01/2024", 
@@ -36,10 +36,10 @@ class UserControllerTest {
     }
 
     @Test
-    void usuarioValido_devuelve201() throws Exception {
+    void usuarioValido_registro_devuelve201() throws Exception {
         ObjectMapper objectMapper = new ObjectMapper();
         String userJson = objectMapper.writeValueAsString(user);
-        	
+        
         Mockito.when(userService.registrarUser(user)).thenReturn(user);
         mockMvc.perform(post("/users/registro").contentType(MediaType.APPLICATION_JSON)
                 .content(userJson))
@@ -47,13 +47,13 @@ class UserControllerTest {
     }
 
     @Test
-	void emailUsuarioInvalido_devuelve400() throws Exception { // Comprobado con el método emailFormatoValido de servicios
+    void emailUsuarioInvalido_registro_devuelve400() throws Exception {
         user.setEmail("carlos.romero");
-    	ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = new ObjectMapper();
         String userJson = objectMapper.writeValueAsString(user);
         
         Mockito.doThrow(new ResponseStatusException(HttpStatus.BAD_REQUEST, "Formato del email incorrecto"))
-        	.when(userService).registrarUser(Mockito.any(User.class));
+                .when(userService).registrarUser(Mockito.any(User.class));
         
         mockMvc.perform(post("/users/registro").contentType(MediaType.APPLICATION_JSON)
                 .content(userJson))
@@ -61,31 +61,71 @@ class UserControllerTest {
     }
 
     @Test
-    void usuarioExistente_devuelve409() throws Exception { //Comprobado en servicios con la comprobación de emailYaRegistrado
+    void usuarioExistente_registro_devuelve409() throws Exception {
         ObjectMapper objectMapper = new ObjectMapper();
         String userJson = objectMapper.writeValueAsString(user);
         
         Mockito.doThrow(new ResponseStatusException(HttpStatus.CONFLICT, "El email ya está registrado"))
-    		.when(userService).registrarUser(Mockito.any(User.class));
+                .when(userService).registrarUser(Mockito.any(User.class));
         
         mockMvc.perform(post("/users/registro")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(userJson))
-                .andExpect(status().isConflict()); //Sujeto a cambios de seguridad
+                .andExpect(status().isConflict());
     }
 
     @Test
-    void passwordDebil_devuelve400() throws Exception {
-    	user.setPassword("password");
+    void passwordDebil_registro_devuelve400() throws Exception {
+        user.setPassword("password");
         ObjectMapper objectMapper = new ObjectMapper();
         String userJson = objectMapper.writeValueAsString(user);
         
         Mockito.doThrow(new ResponseStatusException(HttpStatus.BAD_REQUEST, "Formato de la contraseña incorrecto"))
-    		.when(userService).registrarUser(Mockito.any(User.class));
+                .when(userService).registrarUser(Mockito.any(User.class));
+        
         mockMvc.perform(post("/users/registro")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(userJson))
                 .andExpect(status().isBadRequest());
     }
 
+    // Tests para el método modificar
+    @Test
+    void usuarioValido_modificar_devuelve200() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        String userJson = objectMapper.writeValueAsString(user);
+        
+        Mockito.doNothing().when(userService).modificarUser(user);
+        mockMvc.perform(post("/users/modificar").contentType(MediaType.APPLICATION_JSON)
+                .content(userJson))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Usuario modificado correctamente"));
+    }
+
+    @Test
+    void emailUsuarioInvalido_modificar_devuelve400() throws Exception {
+        user.setEmail("carlos.romero");
+        ObjectMapper objectMapper = new ObjectMapper();
+        String userJson = objectMapper.writeValueAsString(user);
+        
+        Mockito.doThrow(new ResponseStatusException(HttpStatus.BAD_REQUEST, "Formato del email incorrecto"))
+                .when(userService).modificarUser(Mockito.any(User.class));
+        
+        mockMvc.perform(post("/users/modificar").contentType(MediaType.APPLICATION_JSON)
+                .content(userJson))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void usuarioNoExistente_modificar_devuelve404() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        String userJson = objectMapper.writeValueAsString(user);
+        
+        Mockito.doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Usuario no encontrado"))
+                .when(userService).modificarUser(Mockito.any(User.class));
+        
+        mockMvc.perform(post("/users/modificar").contentType(MediaType.APPLICATION_JSON)
+                .content(userJson))
+                .andExpect(status().isNotFound());
+    }
 }

--- a/sgart.backend/src/test/resources/application.properties
+++ b/sgart.backend/src/test/resources/application.properties
@@ -1,4 +1,10 @@
-spring.datasource.url=jdbc:sqlserver://localhost:1433;databaseName=SGART-Users;encrypt=false;trustServerCertificate=false;loginTimeout=30;
+server.port=9000
+
+spring.datasource.url=jdbc:sqlserver://localhost:1433;databaseName=SGART_DB;encrypt=false;trustServerCertificate=true;
 spring.datasource.username=sa
-spring.datasource.password=SGART_2024CAAERM
+spring.datasource.password=Calendario365
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.SQLServerDialect
+
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl


### PR DESCRIPTION
Se añaden a parte de los de los tests correspondientes a la modificación de usuarios, ciertos tests que por errores de subida, no estaban en la rama de registro. 

Además, se añade la comprobación de existencia de un usuario en la base de datos al servicio de modificación, ya que al hacer las pruebas se ha caído en la cuenta de que hacía falta